### PR TITLE
Added schemas_abcd demonstrating compliation of all the schemas at once. Reworked schema_a..d to allow separate compilation with episodes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<version.maven>3.5.2</version.maven>
+		<version.maven>3.3.9</version.maven>
 
 		<!-- SHARED LIBRARY DEPENDENCY VERSIONS -->
 		<version.mail>1.5.0-b01</version.mail>
@@ -91,12 +91,11 @@
 		<version.maven-bundle-plugin>3.5.0</version.maven-bundle-plugin>
 		<version.jaxb2-maven-plugin>2.3.1</version.jaxb2-maven-plugin>
 		<version.maven-clean-plugin>3.0.0</version.maven-clean-plugin>
-		<version.annox>1.0.2</version.annox>
 
 		<!-- maven-jaxb2-plugin DEPENDENCY VERSIONS -->
 		<version.maven-jaxb2-plugin>0.13.3</version.maven-jaxb2-plugin>
-		<version.jaxb2-basics>0.6.4</version.jaxb2-basics>
-		<version.jaxb2-basics-runtime>1.11.1</version.jaxb2-basics-runtime>
+		<version.jaxb2-basics>0.11.1</version.jaxb2-basics>
+		<version.jaxb2-basics-runtime>0.11.1</version.jaxb2-basics-runtime>
 		<version.jaxb2-basics-annotate>1.0.4</version.jaxb2-basics-annotate>
 		<version.jaxb2-commons-lang>2.4</version.jaxb2-commons-lang>
 		<version.jackson-annotations>2.9.4</version.jackson-annotations>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,10 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<artifactId>maven-antrun-plugin</artifactId>
+					<version>1.7</version>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
 					<version>${version.maven-clean-plugin}</version>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -15,6 +15,7 @@
 	<packaging>pom</packaging>
 
 	<modules>
+		<module>schemas_abcd</module>
 		<module>schema_a</module>
 		<module>schema_b</module>
 		<module>schema_c</module>
@@ -23,13 +24,6 @@
 
 	<dependencyManagement>
 		<dependencies>
-			<!-- ANNOX -->
-			<dependency>
-				<groupId>org.jvnet.annox</groupId>
-				<artifactId>annox</artifactId>
-				<version>${version.annox}</version>
-			</dependency>
-
 			<!-- JAXB2 -->
 			<dependency>
 				<groupId>org.jvnet.jaxb2_commons</groupId>
@@ -59,32 +53,14 @@
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>
-		<!-- ANNOX -->
-		<dependency>
-			<groupId>org.jvnet.annox</groupId>
-			<artifactId>annox</artifactId>
-		</dependency>
-
 		<!-- JAXB2 -->
-		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
-			<artifactId>jaxb2-basics</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.jvnet.jaxb2_commons</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
-			<artifactId>jaxb2-basics-annotate</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
-			<artifactId>jaxb2-commons-lang</artifactId>
 		</dependency>
 	</dependencies>
 	<build>
@@ -121,17 +97,5 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.jvnet.jaxb2_commons</groupId>
-				<artifactId>jaxb2-basics</artifactId>
-				<version>${version.jaxb2-basics}</version>
-			</plugin>
-			<plugin>
-				<groupId>org.jvnet.jaxb2_commons</groupId>
-				<artifactId>jaxb2-basics-annotate</artifactId>
-				<version>${version.jaxb2-basics-annotate}</version>
-			</plugin>
-		</plugins>
 	</build>
 </project>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -78,8 +78,8 @@
 						<useDependenciesAsEpisodes>true</useDependenciesAsEpisodes>
 						<schemaDirectory>src/main/schema</schemaDirectory>
 						<bindingDirectory>src/main/schema</bindingDirectory>
-						<schemaExcludes>*.xjb</schemaExcludes>
-						<bindingExcludes>*.xsd</bindingExcludes>
+						<schemaExcludes>*.xsd</schemaExcludes>
+						<catalog>src/main/schema/catalog.cat</catalog>
 						<args>
 							<arg>-Xannotate</arg>
 						</args>

--- a/schema/schema_a/pom.xml
+++ b/schema/schema_a/pom.xml
@@ -29,9 +29,28 @@
 							<goal>generate</goal>
 						</goals>
 						<configuration>
-							<schemaIncludes>schema_a.xsd</schemaIncludes>
-							<bindingIncludes>schema_a.xjb</bindingIncludes>
+							<schemas>
+								<schema><url>http://org.test.schema/schema_a.xsd</url></schema>
+							</schemas>
+							<episode>false</episode>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>process-sources</phase>
+						<configuration>
+							<target>
+								<delete dir="${basedir}/target/generated-sources/xjc/org/test/schema/jaxb2" includes="ObjectFactory.java"/>
+								<delete dir="${basedir}/target/generated-sources/xjc/org/test/schema/jaxb2" includes="package-info.java"/>
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/schema/schema_a/src/main/resources/META-INF/sun-jaxb.episode
+++ b/schema/schema_a/src/main/resources/META-INF/sun-jaxb.episode
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" if-exists="true" version="2.1">
+  <bindings xmlns:tns="http://org.test.schema" if-exists="true" scd="x-schema::tns">
+    <bindings if-exists="true" scd="~tns:SchemaABasicEnumeration">
+      <typesafeEnumClass ref="org.test.schema.jaxb2.SchemaABasicEnumeration"/>
+    </bindings>
+  </bindings>
+</bindings>

--- a/schema/schema_a/src/main/schema/catalog.cat
+++ b/schema/schema_a/src/main/schema/catalog.cat
@@ -1,0 +1,1 @@
+REWRITE_SYSTEM "http://org.test.schema/schema_a.xsd" "schema_a.xsd"

--- a/schema/schema_a/src/main/schema/schema_a.xjb
+++ b/schema/schema_a/src/main/schema/schema_a.xjb
@@ -3,9 +3,9 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
 	xmlns:annox="http://annox.dev.java.net" jaxb:extensionBindingPrefixes="xjc annox"
 	version="2.1">
-	<jaxb:bindings schemaLocation="schema_a.xsd" node="//xs:schema">
+	<jaxb:bindings schemaLocation="http://org.test.schema/schema_a.xsd" node="//xs:schema">
 		<jaxb:schemaBindings>
-			<jaxb:package name="org.test.schema.schema_a.jaxb2" />
+			<jaxb:package name="org.test.schema.jaxb2" />
 		</jaxb:schemaBindings>
 	</jaxb:bindings>
 </jaxb:bindings>

--- a/schema/schema_b/pom.xml
+++ b/schema/schema_b/pom.xml
@@ -34,10 +34,28 @@
 							<goal>generate</goal>
 						</goals>
 						<configuration>
-							<catalog>src/main/schema/catalog.cat</catalog>
-							<schemaIncludes>schema_b.xsd</schemaIncludes>
-							<bindingIncludes>schema_b.xjb</bindingIncludes>
+							<schemas>
+								<schema><url>http://org.test.schema/schema_b.xsd</url></schema>
+							</schemas>
+							<episode>false</episode>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>process-sources</phase>
+						<configuration>
+							<target>
+								<delete dir="${basedir}/target/generated-sources/xjc/org/test/schema/jaxb2" includes="ObjectFactory.java"/>
+								<delete dir="${basedir}/target/generated-sources/xjc/org/test/schema/jaxb2" includes="package-info.java"/>
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/schema/schema_b/src/main/resources/META-INF/sun-jaxb.episode
+++ b/schema/schema_b/src/main/resources/META-INF/sun-jaxb.episode
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" if-exists="true" version="2.1">
+  <bindings xmlns:tns="http://org.test.schema" if-exists="true" scd="x-schema::tns">
+    <bindings if-exists="true" scd="~tns:SchemaBComplexType">
+      <class ref="org.test.schema.jaxb2.SchemaBComplexType"/>
+    </bindings>
+  </bindings>
+</bindings>

--- a/schema/schema_b/src/main/schema/catalog.cat
+++ b/schema/schema_b/src/main/schema/catalog.cat
@@ -1,1 +1,2 @@
-REWRITE_SYSTEM "http://org.test.schema/schema_a" "maven:org.test.schema:schema_a:jar::!"
+REWRITE_SYSTEM "http://org.test.schema/schema_a.xsd" "maven:org.test.schema:schema_a:jar!/schema_a.xsd"
+REWRITE_SYSTEM "http://org.test.schema/schema_b.xsd" "schema_b.xsd"

--- a/schema/schema_b/src/main/schema/schema_b.xjb
+++ b/schema/schema_b/src/main/schema/schema_b.xjb
@@ -3,9 +3,9 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
 	xmlns:annox="http://annox.dev.java.net" jaxb:extensionBindingPrefixes="xjc annox"
 	version="2.1">
-	<jaxb:bindings schemaLocation="schema_b.xsd" node="//xs:schema">
+	<jaxb:bindings schemaLocation="http://org.test.schema/schema_b.xsd" node="//xs:schema">
 		<jaxb:schemaBindings>
-			<jaxb:package name="org.test.schema.schema_b.jaxb2" />
+			<jaxb:package name="org.test.schema.jaxb2" />
 		</jaxb:schemaBindings>
 		<jaxb:bindings node="xs:complexType[@name='SchemaBComplexType']">
 			<annox:annotate>

--- a/schema/schema_c/pom.xml
+++ b/schema/schema_c/pom.xml
@@ -42,9 +42,10 @@
 							<goal>generate</goal>
 						</goals>
 						<configuration>
-							<catalog>src/main/schema/catalog.cat</catalog>
-							<schemaIncludes>schema_c.xsd</schemaIncludes>
-							<bindingIncludes>schema_c.xjb</bindingIncludes>
+							<schemas>
+								<schema><url>http://org.test.schema/schema_c.xsd</url></schema>
+							</schemas>
+							<episode>false</episode>
 						</configuration>
 					</execution>
 				</executions>

--- a/schema/schema_c/src/main/resources/META-INF/sun-jaxb.episode
+++ b/schema/schema_c/src/main/resources/META-INF/sun-jaxb.episode
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" if-exists="true" version="2.1">
+  <bindings xmlns:tns="http://org.test.schema" if-exists="true" scd="x-schema::tns">
+    <schemaBindings map="false">
+      <package name="org.test.schema.jaxb2"/>
+    </schemaBindings>
+    <bindings if-exists="true" scd="~tns:SchemaABasicEnumeration">
+      <typesafeEnumClass ref="org.test.schema.jaxb2.SchemaABasicEnumeration"/>
+    </bindings>
+    <bindings if-exists="true" scd="~tns:SchemaBComplexType">
+      <class ref="org.test.schema.jaxb2.SchemaBComplexType"/>
+    </bindings>
+    <bindings if-exists="true" scd="~tns:SchemaCComplexType">
+      <class ref="schema.test.org.SchemaCComplexType"/>
+    </bindings>
+  </bindings>
+</bindings>

--- a/schema/schema_c/src/main/schema/catalog.cat
+++ b/schema/schema_c/src/main/schema/catalog.cat
@@ -1,2 +1,3 @@
-REWRITE_SYSTEM "http://org.test.schema/schema_a" "maven:org.test.schema:schema_a:jar::!"
-REWRITE_SYSTEM "http://org.test.schema/schema_b" "maven:org.test.schema:schema_b:jar::!"
+REWRITE_SYSTEM "http://org.test.schema/schema_a.xsd" "maven:org.test.schema:schema_a:jar!/schema_a.xsd"
+REWRITE_SYSTEM "http://org.test.schema/schema_b.xsd" "maven:org.test.schema:schema_b:jar!/schema_b.xsd"
+REWRITE_SYSTEM "http://org.test.schema/schema_c.xsd" "schema_c.xsd"

--- a/schema/schema_c/src/main/schema/schema_c.xjb
+++ b/schema/schema_c/src/main/schema/schema_c.xjb
@@ -3,9 +3,9 @@
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
 	xmlns:annox="http://annox.dev.java.net" jaxb:extensionBindingPrefixes="xjc annox"
 	version="2.1">
-	<jaxb:bindings schemaLocation="schema_c.xsd" node="//xs:schema">
+	<jaxb:bindings schemaLocation="http://org.test.schema/schema_c.xsd" node="//xs:schema">
 		<jaxb:schemaBindings>
-			<jaxb:package name="org.test.schema.schema_c.jaxb2" />
+			<jaxb:package name="org.test.schema.jaxb2" />
 		</jaxb:schemaBindings>
 		<jaxb:bindings node="xs:complexType[@name='SchemaCComplexType']">
 			<annox:annotate>

--- a/schema/schema_d/pom.xml
+++ b/schema/schema_d/pom.xml
@@ -42,9 +42,10 @@
 							<goal>generate</goal>
 						</goals>
 						<configuration>
-							<catalog>src/main/schema/catalog.cat</catalog>
-							<schemaIncludes>schema_d.xsd</schemaIncludes>
-							<bindingIncludes>schema_d.xjb</bindingIncludes>
+							<schemas>
+								<schema><url>http://org.test.schema/schema_d.xsd</url></schema>
+							</schemas>
+							<episode>false</episode>
 						</configuration>
 					</execution>
 				</executions>

--- a/schema/schema_d/src/main/resources/META-INF/sun-jaxb.episode
+++ b/schema/schema_d/src/main/resources/META-INF/sun-jaxb.episode
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" if-exists="true" version="2.1">
+  <bindings xmlns:tns="http://org.test.schema" if-exists="true" scd="x-schema::tns">
+    <schemaBindings map="false">
+      <package name="org.test.schema.jaxb2"/>
+    </schemaBindings>
+    <bindings if-exists="true" scd="~tns:SchemaABasicEnumeration">
+      <typesafeEnumClass ref="org.test.schema.jaxb2.SchemaABasicEnumeration"/>
+    </bindings>
+    <bindings if-exists="true" scd="~tns:SchemaBComplexType">
+      <class ref="org.test.schema.jaxb2.SchemaBComplexType"/>
+    </bindings>
+    <bindings if-exists="true" scd="~tns:SchemaDComplexType">
+      <class ref="org.test.schema.jaxb2.SchemaDComplexType"/>
+    </bindings>
+  </bindings>
+</bindings>

--- a/schema/schema_d/src/main/schema/catalog.cat
+++ b/schema/schema_d/src/main/schema/catalog.cat
@@ -1,2 +1,3 @@
-REWRITE_SYSTEM "http://org.test.schema/schema_a" "maven:org.test.schema:schema_a:jar::!"
-REWRITE_SYSTEM "http://org.test.schema/schema_b" "maven:org.test.schema:schema_b:jar::!"
+REWRITE_SYSTEM "http://org.test.schema/schema_a.xsd" "maven:org.test.schema:schema_a:jar!/schema_a.xsd"
+REWRITE_SYSTEM "http://org.test.schema/schema_b.xsd" "maven:org.test.schema:schema_b:jar!/schema_b.xsd"
+REWRITE_SYSTEM "http://org.test.schema/schema_d.xsd" "schema_d.xsd"

--- a/schema/schema_d/src/main/schema/schema_d.xjb
+++ b/schema/schema_d/src/main/schema/schema_d.xjb
@@ -3,10 +3,10 @@
 	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc" xmlns:annox="http://annox.dev.java.net"
 	jaxb:extensionBindingPrefixes="xjc annox" version="2.1">
-	<jaxb:bindings schemaLocation="schema_d.xsd"
+	<jaxb:bindings schemaLocation="http://org.test.schema/schema_d.xsd"
 		node="//xs:schema">
 		<jaxb:schemaBindings>
-			<jaxb:package name="org.test.schema.schema_d.jaxb2" />
+			<jaxb:package name="org.test.schema.jaxb2" />
 		</jaxb:schemaBindings>
 		<jaxb:bindings node="xs:complexType[@name='SchemaDComplexType']">
 			<annox:annotate>

--- a/schema/schema_d/src/main/schema/schema_d.xsd
+++ b/schema/schema_d/src/main/schema/schema_d.xsd
@@ -2,8 +2,8 @@
 <xs:schema targetNamespace="http://org.test.schema"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://org.test.schema"
 	elementFormDefault="qualified">
-	<xs:incude schemaLocation="schema_a.xsd" />
-	<xs:incude schemaLocation="schema_b.xsd" />
+	<xs:include schemaLocation="schema_a.xsd" />
+	<xs:include schemaLocation="schema_b.xsd" />
 	<xs:element name="schemaDComplexType" type="SchemaDComplexType" />
 	<xs:complexType name="SchemaDComplexType">
 		<xs:sequence>

--- a/schema/schemas_abcd/.gitignore
+++ b/schema/schemas_abcd/.gitignore
@@ -1,0 +1,4 @@
+.classpath
+.project
+.settings
+target

--- a/schema/schemas_abcd/pom.xml
+++ b/schema/schemas_abcd/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.test.schema</groupId>
+		<artifactId>schema</artifactId>
+		<version>1.0.0B0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>schemas_abcd</artifactId>
+	<name>Schemas-ABCD</name>
+	<packaging>jar</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jvnet.jaxb2.maven2</groupId>
+				<artifactId>maven-jaxb2-plugin</artifactId>
+				<goals>
+					<goal>generate</goal>
+				</goals>
+				<executions>
+					<execution>
+						<id>xjc-generate-schemas_abcd</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<schemaIncludes>*.xsd</schemaIncludes>
+							<bindingIncludes>*.xjb</bindingIncludes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/schema/schemas_abcd/pom.xml
+++ b/schema/schemas_abcd/pom.xml
@@ -30,7 +30,7 @@
 						</goals>
 						<configuration>
 							<schemaIncludes>*.xsd</schemaIncludes>
-							<bindingIncludes>*.xjb</bindingIncludes>
+							<schemaExcludes>*.none</schemaExcludes>
 						</configuration>
 					</execution>
 				</executions>

--- a/schema/schemas_abcd/src/main/schema/schema_a.xjb
+++ b/schema/schemas_abcd/src/main/schema/schema_a.xjb
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<jaxb:bindings
+	xmlns="http://org.test.schema"
+	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:annox="http://annox.dev.java.net"
+	jaxb:extensionBindingPrefixes="annox"
+	version="2.1">
+	<jaxb:bindings schemaLocation="schema_a.xsd" node="//xs:schema">
+		<jaxb:schemaBindings>
+			<jaxb:package name="org.test.schema.jaxb2" />
+		</jaxb:schemaBindings>
+	</jaxb:bindings>
+</jaxb:bindings>

--- a/schema/schemas_abcd/src/main/schema/schema_a.xsd
+++ b/schema/schemas_abcd/src/main/schema/schema_a.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://org.test.schema"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://org.test.schema"
+	elementFormDefault="qualified">
+	<xs:simpleType name="SchemaABasicEnumeration">	
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BASIC_1"/>
+			<xs:enumeration value="BASIC_2"/>
+			<xs:enumeration value="BASIC_3"/>
+			<xs:enumeration value="BASIC_4"/>
+			<xs:enumeration value="BASIC_5"/>
+			<xs:enumeration value="BASIC_6"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/schema/schemas_abcd/src/main/schema/schema_b.xjb
+++ b/schema/schemas_abcd/src/main/schema/schema_b.xjb
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<jaxb:bindings
+	xmlns="http://org.test.schema"
+	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:annox="http://annox.dev.java.net"
+	jaxb:extensionBindingPrefixes="annox"
+	version="2.1">
+	<jaxb:bindings schemaLocation="schema_b.xsd" node="//xs:schema">
+		<jaxb:bindings node="xs:complexType[@name='SchemaBComplexType']">
+			<annox:annotate>@javax.xml.bind.annotation.XmlRootElement(name = "schemaBComplexType")</annox:annotate>
+		</jaxb:bindings>
+	</jaxb:bindings>
+</jaxb:bindings>

--- a/schema/schemas_abcd/src/main/schema/schema_b.xsd
+++ b/schema/schemas_abcd/src/main/schema/schema_b.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://org.test.schema"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://org.test.schema"
+	elementFormDefault="qualified">
+	<xs:include schemaLocation="schema_a.xsd" />
+	<xs:element name="schemaBComplexType" type="SchemaBComplexType" />
+	<xs:complexType name="SchemaBComplexType">
+		<xs:sequence>
+			<xs:element name="basicEnumInSchemaB" type="SchemaABasicEnumeration" />
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/schema/schemas_abcd/src/main/schema/schema_c.xjb
+++ b/schema/schemas_abcd/src/main/schema/schema_c.xjb
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<jaxb:bindings
+	xmlns="http://org.test.schema"
+	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:annox="http://annox.dev.java.net"
+	jaxb:extensionBindingPrefixes="annox"
+	version="2.1">
+	<jaxb:bindings schemaLocation="schema_c.xsd" node="//xs:schema">
+		<jaxb:bindings node="xs:complexType[@name='SchemaCComplexType']">
+			<annox:annotate>@javax.xml.bind.annotation.XmlRootElement(name = "schemaCComplexType")</annox:annotate>
+		</jaxb:bindings>
+	</jaxb:bindings>
+</jaxb:bindings>

--- a/schema/schemas_abcd/src/main/schema/schema_c.xsd
+++ b/schema/schemas_abcd/src/main/schema/schema_c.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://org.test.schema"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://org.test.schema"
+	elementFormDefault="qualified">
+	<xs:include schemaLocation="schema_a.xsd" />
+	<xs:include schemaLocation="schema_b.xsd" />
+	<xs:element name="schemaCComplexType" type="SchemaCComplexType" />
+	<xs:complexType name="SchemaCComplexType">
+		<xs:sequence>
+			<xs:element name="schemaAEnum" type="SchemaABasicEnumeration" />
+			<xs:element name="schemaBEnum" type="SchemaBComplexType" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="schemaCSimpleType">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="1" />
+			<xs:maxInclusive value="100" />
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/schema/schemas_abcd/src/main/schema/schema_d.xjb
+++ b/schema/schemas_abcd/src/main/schema/schema_d.xjb
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<jaxb:bindings
+	xmlns="http://org.test.schema"
+	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:annox="http://annox.dev.java.net"
+	jaxb:extensionBindingPrefixes="annox" version="2.1">
+	<jaxb:bindings schemaLocation="schema_d.xsd"
+		node="//xs:schema">
+		<jaxb:bindings node="xs:complexType[@name='SchemaDComplexType']">
+			<annox:annotate>@javax.xml.bind.annotation.XmlRootElement(name = "schemaDComplexType")</annox:annotate>
+		</jaxb:bindings>
+	</jaxb:bindings>
+</jaxb:bindings>

--- a/schema/schemas_abcd/src/main/schema/schema_d.xsd
+++ b/schema/schemas_abcd/src/main/schema/schema_d.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://org.test.schema"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://org.test.schema"
+	elementFormDefault="qualified">
+	<xs:include schemaLocation="schema_a.xsd"/>
+	<xs:include schemaLocation="schema_b.xsd"/>
+	<xs:element name="schemaDComplexType" type="SchemaDComplexType" />
+	<xs:complexType name="SchemaDComplexType">
+		<xs:sequence>
+			<xs:element name="schemaAEnum" type="SchemaABasicEnumeration"/>
+			<xs:element name="schemaBEnum" type="SchemaBComplexType" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="schemaDSimpleType">
+		<xs:restriction base="xs:double">
+			<xs:minInclusive value="1000" />
+			<xs:maxInclusive value="1999" />
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
I've added a module `schemas_abcd` which compile all the schemas at once. 

I've also corrected a few `pom.xml`s. Main problem there - you should not include XJC plugins (JAXB2 Basics etc.) as dependencies. These plugins are compile time only, you don't have runtime dependencies there.

Also a few versions were incorrect/incompatible.

`schemas_abcd` compiles fine, `Schema*ComplexType` classes get annotated with `@XmlRootElement`.